### PR TITLE
support single term locale strings, such as "en"

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,13 +20,17 @@ module.exports.parse = parse;
  */
 
 function stringify(language, country){
-  if (!language || !country) return;
+  if (!language) return;
   if (!langs.has('name', language)) return;
-  if (!countries.getCode(country)) return;
   // pair ISO 639-1 language code and ISO 3166-1-alpha-2 country code
   var langCode = langs.where('name', language)['1'];
-  var countryCode = countries.getCode(country);
-  return langCode + '-' + countryCode;
+  if (country) {
+    if (!countries.getCode(country)) return;
+    var countryCode = countries.getCode(country);
+    return langCode + '-' + countryCode;
+  } else {
+    return langCode;
+  }
 };
 
 /**
@@ -41,12 +45,19 @@ function stringify(language, country){
 function parse(string){
   var language = string.split('-')[0];
   var country = string.split('-')[1];
-  if (!language || !country) return;
+  if (!language) return;
   if (!langs.has('1', language)) return;
-  if (!countries.getName(country)) return;
-
-  return {
-    language: langs.where('1', language).name,
-    country: countries.getName(country)
-  };
+  
+  if (country) {
+    if (!countries.getName(country)) return;
+    
+    return {
+      language: langs.where('1', language).name,
+      country: countries.getName(country)
+    }
+  } else {
+    return {
+      language: langs.where('1', language).name
+    }
+  }
 }

--- a/test.js
+++ b/test.js
@@ -16,6 +16,11 @@ describe('locale-string', function(){
     });
 
     it('should return a correct locale string', function(){
+      var res = locale('Finnish', undefined);
+      assert.equal(res, 'fi');
+    });
+
+    it('should return a correct locale string', function(){
       var res = locale('Italian', 'Italy');
       assert.equal(res, 'it-IT');
     });
@@ -36,6 +41,12 @@ describe('locale-string', function(){
       var res = locale.parse('it-IT');
       assert.equal(res.language, 'Italian');
       assert.equal(res.country, 'Italy');
+    });
+
+    it('should return a correct language but undefined country for a dashless string', function(){
+      var res = locale.parse('fi');
+      assert.equal(res.language, 'Finnish');
+      assert(res.country === undefined);
     });
 
     it('should return undefined for a bad string', function(){


### PR DESCRIPTION
This adds supports for single term locales such as "en", as opposed to "en-us".  Currently these are treated as not parseable but are actually legal locales
